### PR TITLE
Update log4j to 2.17.0 to address CVE-2021-45105.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
+            <version>2.17.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
